### PR TITLE
Fix secret name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is a work in progress at this time. Currently the build of the Ansible Auto
 4. Retrieve web address and credentials to log into the Ansible Automation Platform console, and login.
 
     ```shell
-    oc get routes -n ansible-automation-platform | awk {'print $2'} && echo Password: && oc get secrets/example-admin-password -n ansible-automation-platform -o json | jq '.data' |grep -v '{' |grep -v '}' |cut -d '"' -f4 | base64 -d && echo ''
+    oc get routes -n ansible-automation-platform | awk {'print $2'} && echo Password: && oc get secrets/controller-admin-password -n ansible-automation-platform -o json | jq '.data' |grep -v '{' |grep -v '}' |cut -d '"' -f4 | base64 -d && echo ''
     ```
 
     Example Output:


### PR DESCRIPTION
Secret name in deployed demo is "controller-admin-password", this allows retrieval of said password with the script in README.md